### PR TITLE
fix: dont truncate hero size

### DIFF
--- a/src/components/HomepageHeader/index.module.css
+++ b/src/components/HomepageHeader/index.module.css
@@ -3,7 +3,6 @@
 }
 
 .heroBanner {
-  height: calc(100vh - var(--ifm-navbar-height));
   padding: 0 20px;
   overflow: hidden;
   text-align: center;


### PR DESCRIPTION
at certain screen sizes the buttons on the home page get cut off. this pr fixes it (i think, did not test)
<img width="683" alt="image" src="https://user-images.githubusercontent.com/45403290/167268805-ddd966c8-d814-481c-b1b9-8c14c8106dc1.png">
